### PR TITLE
Automatically fall back to Marshal when marshaling tuples

### DIFF
--- a/lib/bud/monkeypatch.rb
+++ b/lib/bud/monkeypatch.rb
@@ -46,7 +46,7 @@ class Struct
     false
   end
 
-  def to_msgpack(out='')
+  def to_msgpack(out=nil)
     self.to_a.to_msgpack(out)
   end
 

--- a/test/tc_lattice.rb
+++ b/test/tc_lattice.rb
@@ -1569,3 +1569,24 @@ class Bug290Test < MiniTest::Unit::TestCase
     end
   end
 end
+
+class MarshalingNestedLatticeObjects
+  include Bud
+
+  state do
+    loopback :lb
+  end
+
+  bootstrap do
+    # Lattice nested in a Ruby object:
+    lb <~ [ [ "localhost", [Bud::MaxLattice.new(0)]] ]
+  end
+
+end
+
+class TestMarshalingNestedLatticeObjects < MiniTest::Unit::TestCase
+  def test_marshal
+    b = MarshalingNestedLatticeObjects.new
+    b.tick
+  end
+end


### PR DESCRIPTION
This commit changes the field marshaler to automatically fall back to Marshal if MessagePack cannot serialize a field.  The old workaround failed when marshaling Ruby objects that contained nested lattices (e.g. a lattice in an array); this commit fixes that problem.

This is still a bit of a hack, but it maybe it's preferable to completely replacing MessagePack with Marshal.
