### PR TITLE
Issue #289. Disallow <= outside bloom blocks.

### DIFF
--- a/lib/bud.rb
+++ b/lib/bud.rb
@@ -71,7 +71,7 @@ module Bud
   attr_reader :tables, :builtin_tables, :channels, :zk_tables, :dbm_tables, :app_tables, :lattices
   attr_reader :push_sources, :push_elems, :push_joins, :scanners, :merge_targets
   attr_reader :this_stratum, :this_rule, :rule_orig_src, :done_bootstrap
-  attr_reader :inside_budinit, :inside_tick
+  attr_reader :inside_tick
   attr_accessor :stratified_rules
   attr_accessor :metrics, :periodics
   attr_accessor :this_rule_context, :qualified_name
@@ -143,7 +143,6 @@ module Bud
     @push_sorted_elems = nil
     @running_async = false
     @bud_started = false
-	@inside_budinit = true
 
     # Setup options (named arguments), along with default values
     @options = options.clone
@@ -173,7 +172,6 @@ module Bud
       @push_joins = num_strata.times.map{[]}
       @merge_targets = num_strata.times.map{Set.new}
     end
-	@inside_budinit = false
   end
 
   def module_wrapper_class(mod)

--- a/lib/bud/bud_meta.rb
+++ b/lib/bud/bud_meta.rb
@@ -17,7 +17,7 @@ class BudMeta #:nodoc: all
       # stratum_map = {fully qualified pred => stratum}. Copy stratum_map data
       # into t_stratum format.
       raise unless @bud_instance.t_stratum.to_a.empty?
-      @bud_instance.t_stratum <= stratum_map.to_a
+      @bud_instance.t_stratum.merge(stratum_map.to_a)
 
       # slot each rule into the stratum corresponding to its lhs pred (from stratum_map)
       stratified_rules = Array.new(top_stratum + 2) { [] }  # stratum -> [ rules ]

--- a/lib/bud/collections.rb
+++ b/lib/bud/collections.rb
@@ -601,8 +601,8 @@ module Bud
     # instantaneously merge items from collection +o+ into +buf+
     def <=(collection)
       toplevel = bud_instance.toplevel
-      if not (toplevel.inside_budinit or toplevel.inside_tick)
-        raise Bud::CompileError, "illegal use of <= outside of bloom block"
+      if not toplevel.inside_tick
+        raise Bud::CompileError, "illegal use of <= outside of bloom block, use <+ instead"
       end
 
       merge(collection)

--- a/test/tc_aggs.rb
+++ b/test/tc_aggs.rb
@@ -376,7 +376,7 @@ class TestAggs < MiniTest::Unit::TestCase
 
   def test_argmin_dups
     a = ArgminDups.new
-    a.t1 <= [[1, 2, 3], [5, 5, 5]]
+    a.t1 <+ [[1, 2, 3], [5, 5, 5]]
     a.tick
     assert_equal([[1, 2, 3]], a.t2.to_a)
     assert_equal([[1, 2, 3]], a.t3.to_a)

--- a/test/tc_collections.rb
+++ b/test/tc_collections.rb
@@ -331,13 +331,13 @@ class TestCollections < MiniTest::Unit::TestCase
     d = DeleteKey.new
     d.tick
     assert_equal(1, d.t1.length)
-    d.del_buf <= [[5, 11]] # shouldn't delete
+    d.del_buf <+ [[5, 11]] # shouldn't delete
     d.tick
     assert_equal(1, d.t1.length)
     d.tick
     assert_equal(1, d.t1.length)
 
-    d.del_buf <= [[5, 10]] # should delete
+    d.del_buf <+ [[5, 10]] # should delete
     d.tick
     assert_equal(1, d.t1.length)
     d.tick
@@ -666,6 +666,14 @@ class TestTransitivity < MiniTest::Unit::TestCase
     assert_equal([[1,1]], p.t1.to_a)
     assert_equal([[1,1]], p.t2.to_a)
     assert_equal([[1,1]], p.t3.to_a)
+  end
+
+  def test_instant_merge_outside_bud
+    program = BabyBud.new
+    program.tbl <+ [['a', 'b', 'c', 'd']]
+    program.scrtch <+ [['a', 'b', 'c', 'd']]
+    assert_raises(Bud::CompileError) { program.tbl <= [['a', 'b', 'c', 'd']] }
+    assert_raises(Bud::CompileError) { program.scrtch <= [['a', 'b', 'c', 'd']] }
   end
 end
 

--- a/test/tc_dbm.rb
+++ b/test/tc_dbm.rb
@@ -76,7 +76,7 @@ class TestDbm < MiniTest::Unit::TestCase
 
   def test_basic_ins
     assert_equal(0, @t.t1.length)
-    @t.in_buf <= [['1', '2', '3', '4'],
+    @t.in_buf <+ [['1', '2', '3', '4'],
                   ['1', '3', '3', '4']]
     @t.tick
     assert_equal(2, @t.t1.length)
@@ -86,7 +86,7 @@ class TestDbm < MiniTest::Unit::TestCase
   end
 
   def test_key_conflict_delta
-    @t.in_buf <= [['1', '2', '3', '4'],
+    @t.in_buf <+ [['1', '2', '3', '4'],
                   ['1', '2', '3', '5']]
     assert_raises(Bud::KeyConstraintError) {@t.tick}
   end
@@ -99,7 +99,7 @@ class TestDbm < MiniTest::Unit::TestCase
   end
 
   def test_key_merge
-    @t.in_buf <= [['1', '2', '3', '4'],
+    @t.in_buf <+ [['1', '2', '3', '4'],
                   ['1', '2', '3', '4'],
                   ['1', '2', '3', '4'],
                   ['1', '2', '3', '4'],
@@ -107,7 +107,7 @@ class TestDbm < MiniTest::Unit::TestCase
                   ['6', '10', '3', '4'],
                   ['6', '10', '3', '4']]
 
-    @t.t1 <= [['1', '2', '3', '4'],
+    @t.t1 <+ [['1', '2', '3', '4'],
               ['1', '2', '3', '4']]
 
     @t.tick
@@ -146,7 +146,7 @@ class TestDbm < MiniTest::Unit::TestCase
   end
 
   def test_pending_ins
-    @t.pending_buf <= [['1', '2', '3', '4']]
+    @t.pending_buf <+ [['1', '2', '3', '4']]
     @t.tick
     assert_equal(0, @t.t1.length)
     @t.tick
@@ -154,31 +154,31 @@ class TestDbm < MiniTest::Unit::TestCase
   end
 
   def test_pending_key_conflict
-    @t.pending_buf <= [['1', '2', '3', '4']]
-    @t.pending_buf2 <= [['1', '2', '3', '5']]
+    @t.pending_buf <+ [['1', '2', '3', '4']]
+    @t.pending_buf2 <+ [['1', '2', '3', '5']]
     assert_raises(Bud::KeyConstraintError) {@t.tick}
   end
 
   def test_basic_del
-    @t.t1 <= [['1', '2', '3', '4'],
+    @t.t1 <+ [['1', '2', '3', '4'],
               ['1', '3', '3', '4'],
               ['2', '4', '3', '4']]
     @t.tick
     assert_equal(3, @t.t1.length)
 
-    @t.del_buf <= [['2', '4', '3', '4']] # should delete
+    @t.del_buf <+ [['2', '4', '3', '4']] # should delete
     @t.tick
     assert_equal(3, @t.t1.length)
     @t.tick
     assert_equal(2, @t.t1.length)
 
-    @t.del_buf <= [['1', '3', '3', '5']] # shouldn't delete
+    @t.del_buf <+ [['1', '3', '3', '5']] # shouldn't delete
     @t.tick
     assert_equal(2, @t.t1.length)
     @t.tick
     assert_equal(2, @t.t1.length)
 
-    @t.del_buf <= [['1', '3', '3', '4']] # should delete
+    @t.del_buf <+ [['1', '3', '3', '4']] # should delete
     @t.tick
     assert_equal(2, @t.t1.length)
     @t.tick
@@ -186,7 +186,7 @@ class TestDbm < MiniTest::Unit::TestCase
   end
 
   def test_chain
-    @t.chain_start <= [[5, 10],
+    @t.chain_start <+ [[5, 10],
                        [10, 15]]
     @t.tick
     assert_equal(2, @t.t2.length)
@@ -194,7 +194,7 @@ class TestDbm < MiniTest::Unit::TestCase
     assert_equal(2, @t.t4.length)
     assert_equal([10,18], @t.t4[[10]])
 
-    @t.chain_del <= [[5,10]]
+    @t.chain_del <+ [[5,10]]
     @t.tick
     assert_equal(2, @t.chain_start.length)
     assert_equal(2, @t.t2.length)
@@ -222,9 +222,9 @@ class TestDbm < MiniTest::Unit::TestCase
   end
 
   def test_join
-    @t.join_t1 <= [[12, 50, 100],
+    @t.join_t1 <+ [[12, 50, 100],
                    [15, 50, 120]]
-    @t.join_t2 <= [[12, 70, 150],
+    @t.join_t2 <+ [[12, 70, 150],
                    [6, 20, 30]]
     @t.tick
 

--- a/test/tc_new_executor.rb
+++ b/test/tc_new_executor.rb
@@ -13,7 +13,7 @@ class PushTests < MiniTest::Unit::TestCase
   end
   def test_simple
     p = SimplePush.new
-    p.r1 <= [[:a,1]]
+    p.r1 <+ [[:a,1]]
     p.tick
     assert_equal([[:a,1]], p.r2.to_a)
     p.tick
@@ -75,9 +75,9 @@ class PushTests < MiniTest::Unit::TestCase
   end
   def test_two_joins
     p = PushTwoJoins.new
-    p.r1 <= [[:a,1]]
-    p.r2 <= [[:a,2]]
-    p.r3 <= [[:a,3]]
+    p.r1 <+ [[:a,1]]
+    p.r2 <+ [[:a,2]]
+    p.r3 <+ [[:a,3]]
     p.tick
     assert_equal([[:a,6]], p.t1.to_a)
   end
@@ -148,7 +148,7 @@ class PushTests < MiniTest::Unit::TestCase
   end
   def test_argagg
     p = PushArgAggTest.new
-    p.r1 <= [[1,'a'],[1,'b'],[2,'b'],[2,'a']]
+    p.r1 <+ [[1,'a'],[1,'b'],[2,'b'],[2,'a']]
     p.tick
     assert_equal([[1,'a'],[1,'b']], p.result.to_a.sort)
   end


### PR DESCRIPTION
When used on scratches/interfaces, <= will have no effect outside a bloom block.
When used on tables, <= will place the tuples in, available in the _next_ tick.

Disallowing <= loses us nothing that <+ doesn't provide, while also eliminating
a user-facing corner case.

Note that inside_budinit was added, because meta_rewrite calls BudCollection <=
during the rewrite phase. Otherwise, we just use inside_tick.

The error message looks like this:
../collections.rb:605:in `<=' : illegal use of <= outside of bloom block (Bud::CompileError)
        from XactKVSProtocol.rb:103:in`<main>'
