### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+rvm:
+  - "1.8.7"
+  - "1.9.2"
+  - "1.9.3"
+
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq -y graphviz
+
+script: bundle exec "cd test; ruby ts_bud.rb"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source "https://rubygems.org"
+gemspec


### PR DESCRIPTION
This commit adds a configuration for Travis CI so that commits and pull requests automatically run the Bud unit tests against Ruby 1.8.7, 1.9.2, and 1.9.3.

Here's the Travis page for my fork, showing test results for my recent commits: https://travis-ci.org/JoshRosen/bud

After merging this, sign into https://travis-ci.org/ with your GitHub account and follow the instructions to enable the GitHub service integration hook for Travis.
