### PR TITLE
Make Max and Min aggs use <=> instead of > or <

### DIFF
--- a/lib/bud/aggs.rb
+++ b/lib/bud/aggs.rb
@@ -36,7 +36,7 @@ module Bud
 
   class Min < ArgExemplary #:nodoc: all
     def trans(the_state, val)
-      if the_state < val
+      if (the_state <=> val) < 0
         return the_state, :ignore
       elsif the_state == val
         return the_state, :keep
@@ -53,8 +53,10 @@ module Bud
 
   class Max < ArgExemplary #:nodoc: all
     def trans(the_state, val)
-      if the_state > val
+      if (the_state <=> val) > 0
         return the_state, :ignore
+      elsif the_state == val
+        return the_state, :keep
       else
         return val, :replace
       end


### PR DESCRIPTION
This comparator is more general, and accepts types like Arrays. This is really useful for vectors, so we can now take the max of vectors like [1, 2, 3] and [1, 2, 4].

Also added the same duplication case from Min for Max as well. I'm not certain why they were different, but I can't think of a reason why max should not return all maximum results, rather than an arbitrary one.

This change is motivated by our CS194-17 project and, uh, our solution won't run if this isn't patched. So we hope you find the change good!
