### PR TITLE
add rakefile with test and release tasks; add version file

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,91 @@
+require 'rake'
+require 'rake/testtask'
+
+PRJ = "bud"
+
+def version
+  @version ||= begin
+    $LOAD_PATH.unshift 'lib'
+    require 'bud/version'
+    warn "Bud::VERSION not a string" unless Bud::VERSION.kind_of? String
+    Bud::VERSION
+  end
+end
+
+def tag
+  @tag ||= "v#{version}"
+end
+
+desc "Run all tests"
+task :test => "test:unit"
+
+TESTS = FileList["test/tc_*.rb"]
+SLOW_TESTS = %w{ test/tc_execmodes.rb }
+
+namespace :test do
+  desc "Run unit tests"
+  Rake::TestTask.new :unit do |t|
+    t.libs << "lib"
+    t.ruby_opts = %w{ -C test }
+    t.test_files = TESTS.sub('test/', '')
+      ### it would be better to make each tc_*.rb not depend on pwd
+  end
+
+  desc "Run quick unit tests"
+  Rake::TestTask.new :quick do |t|
+    t.libs << "lib"
+    t.ruby_opts = %w{ -C test }
+    t.test_files = TESTS.exclude(*SLOW_TESTS).sub('test/', '')
+  end
+
+  desc "Run quick non-zk unit tests"
+  Rake::TestTask.new :quick_no_zk do |t|
+    t.libs << "lib"
+    t.ruby_opts = %w{ -C test }
+    t.test_files = TESTS.
+      exclude('test/tc_zookeeper.rb').
+      exclude(*SLOW_TESTS).
+      sub('test/', '')
+  end
+end
+
+desc "Commit, tag, and push repo; build and push gem"
+task :release => "release:is_new_version" do
+  require 'tempfile'
+  
+  sh "gem build #{PRJ}.gemspec"
+
+  file = Tempfile.new "template"
+  begin
+    file.puts "release #{version}"
+    file.close
+    sh "git commit --allow-empty -a -v -t #{file.path}"
+  ensure
+    file.close unless file.closed?
+    file.unlink
+  end
+
+  sh "git tag #{tag}"
+  sh "git push"
+  sh "git push --tags"
+  
+  sh "gem push #{tag}.gem"
+end
+
+namespace :release do
+  desc "Diff to latest release"
+  task :diff do
+    latest = `git describe --abbrev=0 --tags --match 'v*'`.chomp
+    sh "git diff #{latest}"
+  end
+
+  desc "Log to latest release"
+  task :log do
+    latest = `git describe --abbrev=0 --tags --match 'v*'`.chomp
+    sh "git log #{latest}.."
+  end
+
+  task :is_new_version do
+    abort "#{tag} exists; update version!" unless `git tag -l #{tag}`.empty?
+  end
+end

--- a/bud.gemspec
+++ b/bud.gemspec
@@ -1,6 +1,9 @@
+$LOAD_PATH.unshift 'lib'
+require 'bud/version'
+
 Gem::Specification.new do |s|
   s.name = "bud"
-  s.version = "0.9.8"
+  s.version = Bud::VERSION
   s.authors = ["Peter Alvaro", "Neil Conway", "Joseph M. Hellerstein", "William R. Marczak", "Sriram Srinivasan"]
   s.email = ["bloomdevs@gmail.com"]
   s.summary = "A prototype Bloom DSL for distributed programming."
@@ -11,7 +14,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.8.7'
   s.rubyforge_project = 'bloom-lang'
 
-  s.files = Dir['lib/**/*'] + Dir['bin/*'] + Dir['docs/**/*'] + Dir['examples/**/*'] + %w[README.md LICENSE History.txt]
+  s.files = Dir['lib/**/*'] + Dir['bin/*'] + Dir['docs/**/*'] + Dir['examples/**/*'] + %w[README.md LICENSE History.txt Rakefile]
   s.executables = %w[rebl budplot budvis budtimelines budlabel]
   s.default_executable = 'rebl'
 

--- a/lib/bud/version.rb
+++ b/lib/bud/version.rb
@@ -1,0 +1,3 @@
+module Bud
+  VERSION = "0.9.8"
+end


### PR DESCRIPTION
This rakefile is adapted from my standard one and adds several useful features (run `rake --tasks` for an overview):
- `rake test` and variants: run tests regardless of cwd
- `rake release:log`: see all log messages since last release
- `rake release:diff`: see diff since last release
- `rake release`: do all the steps to release a gem: check that VERSION has been changed, commit, tag, and push, let the user edit the commit message (which will also be visible in the releases tab of the github page), build and push the gem.

There are lots of popular gem release management tools, but this one is simple enough to copy and paste between projects and edit as needed.
